### PR TITLE
Fix/noti read

### DIFF
--- a/src/main/java/com/choongang/auction/streamingauction/controller/AuthController.java
+++ b/src/main/java/com/choongang/auction/streamingauction/controller/AuthController.java
@@ -5,12 +5,14 @@ import com.choongang.auction.streamingauction.domain.member.dto.request.LoginReq
 import com.choongang.auction.streamingauction.domain.member.dto.request.SignUpRequest;
 import com.choongang.auction.streamingauction.domain.member.dto.response.DuplicateCheckResponse;
 import com.choongang.auction.streamingauction.service.MemberService;
+import com.choongang.auction.streamingauction.service.SseEmitterService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -22,6 +24,7 @@ import java.util.Map;
 public class AuthController {
 
     private final MemberService memberService;
+    private final SseEmitterService sseEmitterService;
 
     // 회원가입 요청
     @PostMapping("/signup")
@@ -93,6 +96,9 @@ public class AuthController {
 
         // 쿠키를 클라이언트에 전송
         response.addCookie(cookie);
+
+        // Long memberId =
+        // sseEmitterService.disconnectOnLogout(memberId);
 
         return ResponseEntity.ok().body(Map.of(
                 "message", "로그아웃이 처리되었습니다."

--- a/src/main/java/com/choongang/auction/streamingauction/controller/NotificationController.java
+++ b/src/main/java/com/choongang/auction/streamingauction/controller/NotificationController.java
@@ -6,6 +6,7 @@ import com.choongang.auction.streamingauction.jwt.JwtTokenProvider;
 import com.choongang.auction.streamingauction.service.NotificationService;
 import com.choongang.auction.streamingauction.service.SseEmitterService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -15,6 +16,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/notifications")
 @RequiredArgsConstructor
@@ -49,8 +51,8 @@ public class NotificationController {
     @PatchMapping("/{notificationId}/read")
     public ResponseEntity<Void> markAsRead(@PathVariable Long notificationId,
                                            @RequestHeader("Authorization") String authHeader) {
+        log.info("notificationId {}", notificationId);
         String token = authHeader.replace("Bearer ", "");
-        Long memberId = getMemberIdFromToken(token); // 토큰 검증 및 memberId 추출
         notificationService.markAsRead(notificationId); // memberId 검증은 서비스에서 처리 가능
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/choongang/auction/streamingauction/domain/dto/responseDto/NotificationDto.java
+++ b/src/main/java/com/choongang/auction/streamingauction/domain/dto/responseDto/NotificationDto.java
@@ -1,5 +1,6 @@
 package com.choongang.auction.streamingauction.domain.dto.responseDto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 @Getter
@@ -11,6 +12,7 @@ public class NotificationDto {
     private Long notificationId;
     private String message;
     private String link;
+    @JsonProperty("isRead")
     private boolean isRead;
     private String createdAt;
     private String safeNumber;

--- a/src/main/java/com/choongang/auction/streamingauction/exception/ErrorCode.java
+++ b/src/main/java/com/choongang/auction/streamingauction/exception/ErrorCode.java
@@ -29,6 +29,9 @@ public enum ErrorCode {
     // 인증 관련
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "잘못된 비밀번호입니다."),
 
+    // 알림 관련
+    SSE_CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SSE 연결에 실패했습니다."),
+    NOTIFICATION_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "알림 전송에 실패했습니다."),
 
     // ErrorCode 열거형에 이 부분을 추가하세요
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),

--- a/src/main/java/com/choongang/auction/streamingauction/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/choongang/auction/streamingauction/exception/GlobalExceptionHandler.java
@@ -7,7 +7,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Map;
 

--- a/src/main/java/com/choongang/auction/streamingauction/exception/SseException.java
+++ b/src/main/java/com/choongang/auction/streamingauction/exception/SseException.java
@@ -1,0 +1,18 @@
+package com.choongang.auction.streamingauction.exception;
+
+import lombok.Getter;
+
+@Getter
+public class SseException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public SseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public SseException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/choongang/auction/streamingauction/exception/SseExceptionHandler.java
+++ b/src/main/java/com/choongang/auction/streamingauction/exception/SseExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.choongang.auction.streamingauction.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+
+@ControllerAdvice
+@Slf4j
+public class SseExceptionHandler {
+
+    @ExceptionHandler(SseException.class)
+    public SseEmitter handleSseException(SseException ex, HttpServletRequest request) {
+        if (!MediaType.TEXT_EVENT_STREAM_VALUE.equals(request.getHeader("Accept"))) {
+            throw ex; // SSE가 아니면 GlobalExceptionHandler로 넘김
+        }
+
+        SseEmitter emitter = new SseEmitter();
+        try {
+            log.info("Handling SSE exception: {}", ex.getMessage());
+            emitter.send(SseEmitter.event()
+                    .name("error")
+                    .data("Error: " + ex.getErrorCode().getMessage()));
+        } catch (IOException e) {
+            log.error("Failed to send error event: {}", e.getMessage());
+            emitter.completeWithError(e);
+        }
+        return emitter;
+    }
+}

--- a/src/main/java/com/choongang/auction/streamingauction/service/AuctionService.java
+++ b/src/main/java/com/choongang/auction/streamingauction/service/AuctionService.java
@@ -132,12 +132,11 @@ public class AuctionService {
                         throw new ForbiddenOperationException("판매자만 경매를 종료할 수 있습니다.");
                     }
 
-                    // 최고 입찰자 조회 - 오버로딩이 안 된 상태에선 불가피 한듯..
                     Bid highestBid = null;
                     try {
                         highestBid = bidRepository.findTopByAuctionIdOrderByBidAmountDesc(auctionEntity.getId());
                     } catch (Exception e) {
-                        log.error("최고 입찰 조회 중 오류 발생. 경매 ID: {}, 오류: {}", auctionEntity.getId(), e.getMessage());
+                        log.info("종료된 경매에 입찰 내역이 없습니다 또는 조회 실패. 상품 ID: {}", auctionRequestDto.productId());
                     }
 
                     // 종료 시간 업데이트, 경매 상태 변경
@@ -150,27 +149,21 @@ public class AuctionService {
                     // 경매 종료 로그 추가
                     log.info("경매 종료됨. 상품 ID: {}, 종료 시간: {}", auctionRequestDto.productId(), auctionEntity.getEndTime());
 
-                    // 최고 입찰자 조회 - 오버로딩이 안 된 상태에선 불가피 한듯..
                     Long sellerId = auctionEntity.getProduct().getMember().getId();
+                    Long winnerId = highestBid.getMember().getId();
 
-                    if (highestBid != null) {
-                        Long winnerId = highestBid.getMember().getId();
+                    TradeRecord tradeRecord = TradeRecord.builder()
+                            .itemName(auctionEntity.getProduct().getName())
+                            .amount(auctionEntity.getCurrentPrice())
+                            .seller(sellerId)
+                            .buyer(winnerId)
+                            .productId(auctionRequestDto.productId())
+                            .build();
 
-                        TradeRecord tradeRecord = TradeRecord.builder()
-                                .itemName(auctionEntity.getProduct().getName())
-                                .amount(auctionEntity.getCurrentPrice())
-                                .seller(sellerId)
-                                .buyer(winnerId)
-                                .productId(auctionRequestDto.productId())
-                                .build();
+                    tradeRecordRepository.save(tradeRecord);
+                    log.info("TradeRecord 저장 완료. Trade ID: {}", tradeRecord.getTradeId());
 
-                        tradeRecordRepository.save(tradeRecord);
-                        log.info("TradeRecord 저장 완료. Trade ID: {}", tradeRecord.getTradeId());
-
-                        notificationService.handleAuctionEnd(auctionRequestDto.productId(), sellerId, winnerId);
-                    } else {
-                        log.info("종료된 경매에 입찰 내역이 없습니다 또는 조회 실패. 상품 ID: {}", auctionRequestDto.productId());
-                    }
+                    notificationService.handleAuctionEnd(auctionRequestDto.productId(), sellerId, winnerId);
                 },
                 () -> {
                     throw new AuctionNotFoundException("경매가 존재하지 않습니다.");
@@ -179,53 +172,37 @@ public class AuctionService {
     }
 
     // 입찰자의 입찰에 의한 경매 종료 처리 (auction status 'COMPLETED'로 업데이트 + 종료시간 업데이트)
-    public void closeAuctionByBuyer(AuctionRequestDto auctionRequestDto) {
-        // 해당 상품의 경매방 찾기
-        Optional<Auction> foundAuctionByProductId = auctionRepository.findByProduct_ProductId(auctionRequestDto.productId());
+    public void closeAuctionByBuyer(Auction foundAuction, Bid highestBid) {
+        Long productId = foundAuction.getProduct().getProductId();
+        if (foundAuction.getStatus() == Status.COMPLETED) {
+            log.info("이미 종료된 경매입니다. 상품 ID: {}", productId);
+            return;
+        }
 
-        // 경매 정보가 없을 경우, 로깅 후 종료
-        foundAuctionByProductId.ifPresentOrElse(
-                auctionEntity -> {
-                    // 경매 상태가 이미 '완료'인 경우 처리 (중복 종료 방지)
-                    if (auctionEntity.getStatus() == Status.COMPLETED) {
-                        log.info("이미 종료된 경매입니다. 상품 ID: {}", auctionRequestDto.productId());
-                        return;
-                    }
+        // 종료 시간 업데이트, 경매 상태 변경
+        foundAuction.setEndTime(LocalDateTime.now());
+        foundAuction.setStatus(Status.COMPLETED);
 
-                    // 종료 시간 업데이트, 경매 상태 변경
-                    auctionEntity.setEndTime(LocalDateTime.now());
-                    auctionEntity.setStatus(Status.COMPLETED);
+        // 경매 종료 처리 후 DB에 저장
+        auctionRepository.save(foundAuction);
 
-                    // 경매 종료 처리 후 DB에 저장
-                    auctionRepository.save(auctionEntity);
+        // 경매 종료 로그 추가
+        log.info("경매 종료됨. 상품 ID: {}, 종료 시간: {}", productId, foundAuction.getEndTime());
 
-                    // 경매 종료 로그 추가
-                    log.info("경매 종료됨. 상품 ID: {}, 종료 시간: {}", auctionRequestDto.productId(), auctionEntity.getEndTime());
+        Long sellerId = foundAuction.getProduct().getMember().getId();
+        Long winnerId = highestBid.getMember().getId();
 
-                    // 최고 입찰자 조회 - 입찰 로직에 있지만 경매종료 2가지 조건에 따라 오버로딩으로 나누지 않는 상황이라면
-                    // 일단 넣어두기
-                    Bid highestBid = bidRepository.findTopByAuctionIdOrderByBidAmountDesc(auctionEntity.getId());
-                    if (highestBid == null) {
-                        log.info("종료된 경매에 입찰 내역이 없습니다. 상품 ID: {}", auctionRequestDto.productId());
-                    } else {
-                        // TradeRecord 생성 및 저장
-                        TradeRecord tradeRecord = TradeRecord.builder()
-                                .itemName(auctionEntity.getProduct().getName()) // 상품 이름
-                                .amount(auctionEntity.getCurrentPrice())        // 낙찰 금액 (Auction의 현재가)
-                                .seller(auctionEntity.getProduct().getMember().getId())            // 판매자 ID
-                                .buyer(highestBid.getMember().getId())          // 낙찰자 ID (Bid에서)
-                                .productId(auctionRequestDto.productId())    // 상품 ID
-                                .build();
+        TradeRecord tradeRecord = TradeRecord.builder()
+                .itemName(foundAuction.getProduct().getName())
+                .amount(highestBid.getBidAmount())
+                .seller(sellerId)
+                .buyer(winnerId)
+                .productId(productId)
+                .build();
 
-                        tradeRecordRepository.save(tradeRecord);
-                        log.info("TradeRecord 저장 완료. Trade ID: {}", tradeRecord.getTradeId());
-                    }
-                    // 후속 처리: 낙찰자에게 알림, 판매 상태로 변경 등 추가적인 로직 처리
-                    // 예: notifyWinner(auctionEntity.getWinningUserName());
-                },
-                () -> log.info("경매가 존재하지 않습니다. 상품 ID: {}", auctionRequestDto.productId()) // 경매가 없을 경우 로깅
-        );
+        tradeRecordRepository.save(tradeRecord);
+        log.info("TradeRecord 저장 완료. Trade ID: {}", tradeRecord.getTradeId());
+
+        notificationService.handleAuctionEnd(productId, sellerId, winnerId);
     }
-
-
 }

--- a/src/main/java/com/choongang/auction/streamingauction/service/BidService.java
+++ b/src/main/java/com/choongang/auction/streamingauction/service/BidService.java
@@ -64,7 +64,7 @@ public class BidService {
         if (highestBid.getBidAmount() >= foundAuction.getProduct().getBuyNowPrice()){
             log.info("이미 즉시 낙찰가가 있습니다.");
             //경매 종료
-            auctionService.closeAuctionByBuyer(new AuctionRequestDto(foundAuction.getProduct().getProductId()));
+            auctionService.closeAuctionByBuyer(foundAuction, highestBid);
             // 조회된 최고 입찰자의 정보 반환
             return new BidResponseDto(
                     highestBid.getMember() != null ? highestBid.getMember().getName() : "Unknown",
@@ -77,7 +77,7 @@ public class BidService {
             //경매 현재가 업데이트
             auctionService.updateAuctionCurrentPrice(foundAuction.getId() , bidRequestDto.bidAmount());
             //경매 종료
-            auctionService.closeAuctionByBuyer(new AuctionRequestDto(foundAuction.getProduct().getProductId()));
+            auctionService.closeAuctionByBuyer(foundAuction, highestBid);
             return new BidResponseDto(
                     bidEntity.getMember().getName(),  // 최고 입찰자
                     bidEntity.getBidAmount()           // 입찰 금액

--- a/src/main/java/com/choongang/auction/streamingauction/service/NotificationService.java
+++ b/src/main/java/com/choongang/auction/streamingauction/service/NotificationService.java
@@ -32,6 +32,7 @@ public class NotificationService {
         Notification notification = notificationRepository.findById(notificationId)
                 .orElseThrow(() -> new RuntimeException("알림을 찾을 수 없음"));
         notification.setRead(true);
+        log.info("Mark as read: {}", notification.isRead());
     }
 
     @Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,9 @@ spring:
     multipart:
       max-file-size: 10MB      # 단일 파일의 최대 크기
       max-request-size: 10MB
-
+  mvc:
+    async:
+      request-timeout: 60000
   #  mail:
   #    host: smtp.naver.com
   #    port: 465


### PR DESCRIPTION
SseEmitterService
- 단일 스레드 풀 사용
- 클라이언트에서 새로고침(F5)이나 URL을 사용한 접속 시, SSE연결이 종료되는데 기존 emitter을 정리 및 heartbeat를 송신하는 과정에서 문제가 있었습니다. 현재는 SseEmitter.complete()의 비동기 특성을 고려하면서도, Spring의 SseEmitter가 요구하는 연결 종료 및 리소스 정리 역할을 유지하면서 해결했습니다. onCompletion을 직접 조작하지 않고 조건을 추가함으로써, 기존 emitter와 새 emitter의 생명주기를 명확히 분리해 충돌을 방지했습니다.
-로그아웃 메서드 추가 (SecurityContextHolder에 member id가 저장되면 사용 예정)
-에러 핸들링 추가

